### PR TITLE
All response typed

### DIFF
--- a/lib/swagger2_rbs/rbs_type.rb
+++ b/lib/swagger2_rbs/rbs_type.rb
@@ -1,0 +1,46 @@
+module Swagger2Rbs
+  class RbsType
+    attr_reader :data, :symbolize_keys
+    def initialize(data, symbolize_keys: true)
+      @data = data
+      @symbolize_keys = symbolize_keys
+    end
+
+    def write_types
+      return nil unless HashHelper.present? data
+      typed = (data.is_a?(Array) ? data[0] : data)&.map{ |k, v| to_typed(k, v) }.join(', ')
+      if data.is_a?(Array)
+        "Array[{ #{typed} }]"
+      else
+        "{ #{typed} }"
+      end
+    end
+
+    def type_case(str)
+      case str
+      when "boolean"
+        "bool"
+      when nil
+        "untyped"
+      else
+        str&.capitalize
+      end
+    end
+
+    def key_to_typed(k)
+      return "#{k}:" if @symbolize_keys
+      "\"#{k}\" =>"
+    end
+
+    def to_typed(k, v)
+      return "#{key_to_typed(k)} #{type_case(v)}" unless v.is_a?(Array) || v.is_a?(Hash)
+      return "#{key_to_typed(k)} {#{v.map{ |k2, v2| to_typed(k2, v2) }.join(", ")}}" if v.is_a?(Hash)
+
+      if v[0]&.is_a?(Hash)
+        "#{key_to_typed(k)} Array[{" + v[0].map{ |k, v| to_typed(k, v) }.join(", ") + "}]"
+      else
+        "#{key_to_typed(k)} Array[#{type_case(v[0])}]"
+      end
+    end
+  end
+end

--- a/lib/swagger2_rbs/rest_endpoint.rb
+++ b/lib/swagger2_rbs/rest_endpoint.rb
@@ -37,8 +37,8 @@ module Swagger2Rbs
         path_parameters: parameters,
         method_name: method_name,
         body: body,
-        response: response_typed("200"),
-        all_responses_typed: all_responses_typed
+        response: response("200"),
+        all_responses: all_responses
       }
     rescue => e
       raise e, "Context: #{path} #{method} Message: #{e.message}"

--- a/lib/swagger2_rbs/rest_endpoint.rb
+++ b/lib/swagger2_rbs/rest_endpoint.rb
@@ -78,9 +78,9 @@ module Swagger2Rbs
     end
 
     def all_responses_for_return_method
-      return '{ "200" => response.body }' if all_responses.empty?
+      return '{ "200" => response }' if all_responses.empty?
 
-      result = all_responses.keys.map{|key| "\"#{key}\" => response.body" }.join(", ")
+      result = all_responses.keys.map{|key| "\"#{key}\" => response" }.join(", ")
       "{ #{result} }"
     end
 

--- a/lib/swagger2_rbs/rest_endpoint.rb
+++ b/lib/swagger2_rbs/rest_endpoint.rb
@@ -37,7 +37,7 @@ module Swagger2Rbs
         path_parameters: parameters,
         method_name: method_name,
         body: body,
-        response: response_typed,
+        response: response_typed("200"),
       }
     rescue => e
       raise e, "Context: #{path} #{method} Message: #{e.message}"
@@ -64,8 +64,8 @@ module Swagger2Rbs
       schema_to_typed(body_schema)
     end
 
-    def response
-      schema = resolve_all_of(@props.dig("responses", "200", "content", "application/json", "schema"))
+    def response(http_code)
+      schema = resolve_all_of(@props.dig("responses", http_code, "content", "application/json", "schema"))
       schema_to_typed(schema, {})
     end
 

--- a/lib/swagger2_rbs/rest_endpoint.rb
+++ b/lib/swagger2_rbs/rest_endpoint.rb
@@ -38,6 +38,7 @@ module Swagger2Rbs
         method_name: method_name,
         body: body,
         response: response_typed("200"),
+        all_response_typed: all_response_typed
       }
     rescue => e
       raise e, "Context: #{path} #{method} Message: #{e.message}"

--- a/lib/swagger2_rbs/rest_endpoint.rb
+++ b/lib/swagger2_rbs/rest_endpoint.rb
@@ -20,7 +20,7 @@ module Swagger2Rbs
         typed_parameters_for_method: typed_parameters_for_method,
         has_body: body?,
         method_name: method_name,
-        response_typed: response_typed,
+        all_responses_typed: all_responses_typed,
       }
     rescue => e
       raise e, "Context: #{path} #{method} Message: #{e.message}"
@@ -38,7 +38,7 @@ module Swagger2Rbs
         method_name: method_name,
         body: body,
         response: response_typed("200"),
-        all_response_typed: all_response_typed
+        all_responses_typed: all_responses_typed
       }
     rescue => e
       raise e, "Context: #{path} #{method} Message: #{e.message}"

--- a/lib/swagger2_rbs/rest_endpoint.rb
+++ b/lib/swagger2_rbs/rest_endpoint.rb
@@ -21,6 +21,7 @@ module Swagger2Rbs
         has_body: body?,
         method_name: method_name,
         all_responses_typed: all_responses_typed,
+        all_responses_for_return_method: all_responses_for_return_method,
       }
     rescue => e
       raise e, "Context: #{path} #{method} Message: #{e.message}"
@@ -68,6 +69,19 @@ module Swagger2Rbs
     def response(http_code)
       schema = resolve_all_of(@props.dig("responses", http_code, "content", "application/json", "schema"))
       schema_to_typed(schema, {})
+    end
+
+    def all_responses
+      result = @props.dig("responses").keys.reduce({}) do |memo, key|
+        memo.merge({ key => response(key) })
+      end
+    end
+
+    def all_responses_for_return_method
+      return '{ "200" => response.body }' if all_responses.empty?
+
+      result = all_responses.keys.map{|key| "\"#{key}\" => response.body" }.join(", ")
+      "{ #{result} }"
     end
 
     def parameters_for_method

--- a/lib/swagger2_rbs/rest_endpoint_typed.rb
+++ b/lib/swagger2_rbs/rest_endpoint_typed.rb
@@ -47,6 +47,8 @@ module Swagger2Rbs
       case str
       when "boolean"
         "bool"
+      when nil
+        "untyped"
       else
         str&.capitalize
       end

--- a/lib/swagger2_rbs/rest_endpoint_typed.rb
+++ b/lib/swagger2_rbs/rest_endpoint_typed.rb
@@ -21,6 +21,18 @@ module Swagger2Rbs
       write_types(response(http_code))
     end
 
+    def all_responses
+      result = @props.dig("responses").keys.reduce({}) do |memo, key|
+        memo.merge({ key => response(key) })
+      end
+    end
+
+    def all_responses_typed
+      return "untyped response" unless @props.dig("responses")
+
+      write_types(all_responses)
+    end
+
     def write_types(data)
       return nil unless HashHelper.present? data
       typed = (data.is_a?(Array) ? data[0] : data)&.map{ |k, v| to_typed(k, v) }.join(', ')

--- a/lib/swagger2_rbs/rest_endpoint_typed.rb
+++ b/lib/swagger2_rbs/rest_endpoint_typed.rb
@@ -21,12 +21,6 @@ module Swagger2Rbs
       write_types(response(http_code))
     end
 
-    def all_responses
-      result = @props.dig("responses").keys.reduce({}) do |memo, key|
-        memo.merge({ key => response(key) })
-      end
-    end
-
     def all_responses_typed
       return "untyped response" unless @props.dig("responses")
 

--- a/lib/swagger2_rbs/rest_endpoint_typed.rb
+++ b/lib/swagger2_rbs/rest_endpoint_typed.rb
@@ -22,7 +22,7 @@ module Swagger2Rbs
     end
 
     def all_responses_typed
-      return "untyped response" unless @props.dig("responses")
+      return '{ "200" => untyped }' unless @props.dig("responses")
 
       write_types(all_responses)
     end
@@ -49,13 +49,13 @@ module Swagger2Rbs
     end
 
     def to_typed(k, v)
-      return "#{k}: #{type_case(v)}" unless v.is_a?(Array) || v.is_a?(Hash)
-      return "#{k}: {#{v.map{ |k2, v2| to_typed(k2, v2) }.join(", ")}}" if v.is_a?(Hash)
+      return "\"#{k}\" => #{type_case(v)}" unless v.is_a?(Array) || v.is_a?(Hash)
+      return "\"#{k}\" => {#{v.map{ |k2, v2| to_typed(k2, v2) }.join(", ")}}" if v.is_a?(Hash)
 
       if v[0]&.is_a?(Hash)
-        "#{k}: Array[{" + v[0].map{ |k, v| to_typed(k, v) }.join(", ") + "}]"
+        "\"#{k}\" => Array[{" + v[0].map{ |k, v| to_typed(k, v) }.join(", ") + "}]"
       else
-        "#{k}: Array[#{type_case(v[0])}]"
+        "\"#{k}\" => Array[#{type_case(v[0])}]"
       end
     end
 

--- a/lib/swagger2_rbs/rest_endpoint_typed.rb
+++ b/lib/swagger2_rbs/rest_endpoint_typed.rb
@@ -17,8 +17,8 @@ module Swagger2Rbs
       write_types(body)
     end
 
-    def response_typed
-      write_types(response)
+    def response_typed(http_code)
+      write_types(response(http_code))
     end
 
     def write_types(data)
@@ -54,7 +54,7 @@ module Swagger2Rbs
     def schema_to_typed(schema, memo = {})
       return nil unless schema
 
-      properties = schema["type"]["array"] ? schema["items"]["properties"] : schema["properties"]
+      properties = schema["type"] == "array" ? schema["items"]["properties"] : schema["properties"]
 
       result = properties&.reduce(memo)do |memo, (k,v)|
         if v["type"] == "object"
@@ -69,7 +69,7 @@ module Swagger2Rbs
           memo.merge({k => v["type"] })
         end
       end
-      return [result] if schema["type"]["array"]
+      return [result] if schema["type"] == "array"
 
       result
     end

--- a/lib/swagger2_rbs/rest_endpoint_typed.rb
+++ b/lib/swagger2_rbs/rest_endpoint_typed.rb
@@ -1,5 +1,5 @@
+require_relative './rbs_type'
 module Swagger2Rbs
-
   module RestEndpointTyped
     def typed_parameters_for_method
       options_typed = "?Hash[untyped, untyped] options"
@@ -14,72 +14,17 @@ module Swagger2Rbs
     end
 
     def body_typed
-      write_types(body)
+      RbsType.new(body).write_types
     end
 
     def response_typed(http_code)
-      write_types(response(http_code))
+      RbsType.new(response(http_code), symbolize_keys: false).write_types
     end
 
     def all_responses_typed
       return '{ "200" => untyped }' unless @props.dig("responses")
 
-      write_types(all_responses)
-    end
-
-    def write_types(data)
-      return nil unless HashHelper.present? data
-      typed = (data.is_a?(Array) ? data[0] : data)&.map{ |k, v| to_typed(k, v) }.join(', ')
-      if data.is_a?(Array)
-        "Array[{ #{typed} }]"
-      else
-        "{ #{typed} }"
-      end
-    end
-
-    def type_case(str)
-      case str
-      when "boolean"
-        "bool"
-      when nil
-        "untyped"
-      else
-        str&.capitalize
-      end
-    end
-
-    def to_typed(k, v)
-      return "\"#{k}\" => #{type_case(v)}" unless v.is_a?(Array) || v.is_a?(Hash)
-      return "\"#{k}\" => {#{v.map{ |k2, v2| to_typed(k2, v2) }.join(", ")}}" if v.is_a?(Hash)
-
-      if v[0]&.is_a?(Hash)
-        "\"#{k}\" => Array[{" + v[0].map{ |k, v| to_typed(k, v) }.join(", ") + "}]"
-      else
-        "\"#{k}\" => Array[#{type_case(v[0])}]"
-      end
-    end
-
-    def schema_to_typed(schema, memo = {})
-      return nil unless schema
-
-      properties = schema["type"] == "array" ? schema["items"]["properties"] : schema["properties"]
-
-      result = properties&.reduce(memo)do |memo, (k,v)|
-        if v["type"] == "object"
-          memo.merge({k => schema_to_typed(v, {})})
-        elsif v["type"] == "array"
-          if v.dig("items", "type") == "object"
-            memo.merge({k => [schema_to_typed(v["items"], {})] })
-          else
-            memo.merge({k => [v.dig("items", "type")] })
-          end
-        else
-          memo.merge({k => v["type"] })
-        end
-      end
-      return [result] if schema["type"] == "array"
-
-      result
+      RbsType.new(all_responses, symbolize_keys: false).write_types
     end
   end
 end

--- a/lib/templates/http_client.rb.erb
+++ b/lib/templates/http_client.rb.erb
@@ -13,11 +13,13 @@ class <%= @module_name %>
 
   <%- unless endpoint[:has_body] -%>
   def <%= endpoint[:method_name] %>(<%= endpoint[:parameters_for_method] %>)
-    self.class.<%= endpoint[:http_method] %>("<%= endpoint[:path] %>", options)
+    response = self.class.<%= endpoint[:http_method] %>("<%= endpoint[:path] %>", options)
+    [response, <%= endpoint[:all_responses_for_return_method] %>]
   end
   <%- else -%>
   def <%= endpoint[:method_name] %>(<%= endpoint[:parameters_for_method] %>)
-    self.class.<%= endpoint[:http_method] %>("<%= endpoint[:path] %>", { body: body.to_json }.merge(options))
+    response = self.class.<%= endpoint[:http_method] %>("<%= endpoint[:path] %>", { body: body.to_json }.merge(options))
+    [response, <%= endpoint[:all_responses_for_return_method] %>]
   end
   <%- end -%>
   <%- end -%>

--- a/lib/templates/http_client.rbs.erb
+++ b/lib/templates/http_client.rbs.erb
@@ -20,6 +20,6 @@ class <%= @module_name %>
   def initialize: -> void
   <%- @data[:endpoints].each do |endpoint| -%>
 
-  def <%= endpoint[:method_name] %>: <%= endpoint[:typed_parameters_for_method] %> -> HTTParty::Response
+  def <%= endpoint[:method_name] %>: <%= endpoint[:typed_parameters_for_method] %> -> [HTTParty::Response, <%= endpoint[:all_responses_typed] %>]
   <%- end -%>
 end

--- a/lib/templates/http_client.rbs.erb
+++ b/lib/templates/http_client.rbs.erb
@@ -4,6 +4,7 @@ module HTTParty
   class Response
     def body: -> untyped
     def success?: -> bool
+    def code: -> Integer
   end
 end
 
@@ -12,10 +13,10 @@ class <%= @module_name %>
 
   def self.headers: (untyped headers) -> void
   def self.base_uri: (String uri) -> void
-  def self.get: (String path, untyped options) -> void
-  def self.post: (String path, untyped options) -> void
-  def self.put: (String path, untyped options) -> void
-  def self.delete: (String path, untyped options) -> void
+  def self.get: (String path, untyped options) -> HTTParty::Response
+  def self.post: (String path, untyped options) -> HTTParty::Response
+  def self.put: (String path, untyped options) -> HTTParty::Response
+  def self.delete: (String path, untyped options) -> HTTParty::Response
 
   def initialize: -> void
   <%- @data[:endpoints].each do |endpoint| -%>

--- a/spec/rbs_type_spec.rb
+++ b/spec/rbs_type_spec.rb
@@ -1,0 +1,20 @@
+require 'json'
+require 'pry'
+require_relative '../lib/swagger2_rbs'
+require_relative '../lib/swagger2_rbs/rbs_type'
+
+
+describe "RbsType" do
+  let(:subject) {  }
+  it 'nil values' do
+    data = { "400" => nil, "200" => { "success" => "string" } }
+    result = Swagger2Rbs::RbsType.new(data, symbolize_keys: false).write_types
+    expect(result).to eq('{ "400" => untyped, "200" => {"success" => String} }')
+  end
+
+  it 'array' do
+    data = { "errors" => [{ "success" => "string" }] }
+    result = Swagger2Rbs::RbsType.new(data).write_types
+    expect(result).to eq('{ errors: Array[{success: String}] }')
+  end
+end

--- a/spec/rest_endpoint_spec.rb
+++ b/spec/rest_endpoint_spec.rb
@@ -16,92 +16,92 @@ describe 'Swagger2Rbs::RestEndpoint' do
 
     describe "#write_types" do
       it 'nil values' do
-        data = { "400" => nil, "200" => { success: "string" } }
+        data = { "400" => nil, "200" => { "success" => "string" } }
         result = subject.write_types(data)
         expect(result).to eq('{ "400" => untyped, "200" => {"success" => String} }')
       end
 
       it 'array' do
-        data = { "errors" => [{ success: "string" }] }
+        data = { "errors" => [{ "success" => "string" }] }
         result = subject.write_types(data)
-        expect(result).to eq("{ errors: Array[{success: String}] }")
+        expect(result).to eq('{ "errors" => Array[{"success" => String}] }')
       end
     end
 
     it '#method_name' do
-      expect(subject.method_name).to eq("get_access_token")
+      expect(subject.method_name).to eq('get_access_token')
     end
 
     describe "#path_with_parameters" do
       describe 'path /oauth/token' do
         let(:path_method) { ["/oauth/token", "post"] }
-        it { expect(subject.path_with_parameters).to eq("/oauth/token") }
+        it { expect(subject.path_with_parameters).to eq('/oauth/token') }
       end
 
       describe 'path /accounts/{id}' do
         let(:path_method) { ["/accounts/{id}", "get"] }
-        it { expect(subject.path_with_parameters).to eq("/accounts/\#{id}") }
+        it { expect(subject.path_with_parameters).to eq('/accounts/#{id}') }
       end
     end
 
     describe "#response_typed" do
       describe 'path /oauth/token 200' do
         let(:path_method) { ["/oauth/token", "post"] }
-        it { expect(subject.response_typed("200")).to eq("{ access_token: String, token_type: String, expires_in: Integer, scope: String, created_at: Integer }") }
+        it { expect(subject.response_typed("200")).to eq('{ "access_token" => String, "token_type" => String, "expires_in" => Integer, "scope" => String, "created_at" => Integer }') }
       end
 
       describe 'path /accounts/{id} 200' do
         let(:path_method) { ["/accounts/{id}", "get"] }
-        it { expect(subject.response_typed("200")).to eq("{ data: {id: String, external_id: String, business_information: {name: String, type: String, website: String, identification_number: String, year_established: Number, annual_revenue: {value: Number, amount: Number, currency: String}, fulltime_employees: Integer, parttime_employees: Integer}, industry: {type: String, class_code: String, subclass_code: String}, addresses: Array[{type: String, address_line: String, city: String, state: String, country_code: String, postal_code: String}], email: String, phone_number: String} }") }
+        it { expect(subject.response_typed("200")).to eq('{ "data" => {"id" => String, "external_id" => String, "business_information" => {"name" => String, "type" => String, "website" => String, "identification_number" => String, "year_established" => Number, "annual_revenue" => {"value" => Number, "amount" => Number, "currency" => String}, "fulltime_employees" => Integer, "parttime_employees" => Integer}, "industry" => {"type" => String, "class_code" => String, "subclass_code" => String}, "addresses" => Array[{"type" => String, "address_line" => String, "city" => String, "state" => String, "country_code" => String, "postal_code" => String}], "email" => String, "phone_number" => String} }') }
       end
 
       describe 'path /accounts/{id} 404' do
         let(:path_method) { ["/accounts/{id}", "get"] }
-        it { expect(subject.response_typed("404")).to eq("{ errors: Array[{source: String, type: String, message: String}] }") }
+        it { expect(subject.response_typed("404")).to eq('{ "errors" => Array[{"source" => String, "type" => String, "message" => String}] }') }
       end
     end
 
     describe "#all_responses_typed" do
       describe 'path /accounts/{id} 200' do
         let(:path_method) { ["/accounts/{id}", "get"] }
-        it { expect(subject.all_responses_typed).to eq("{ 200: {data: {id: String, external_id: String, business_information: {name: String, type: String, website: String, identification_number: String, year_established: Number, annual_revenue: {value: Number, amount: Number, currency: String}, fulltime_employees: Integer, parttime_employees: Integer}, industry: {type: String, class_code: String, subclass_code: String}, addresses: Array[{type: String, address_line: String, city: String, state: String, country_code: String, postal_code: String}], email: String, phone_number: String}}, 404: {errors: Array[{source: String, type: String, message: String}]} }") }
+        it { expect(subject.all_responses_typed).to eq('{ "200" => {"data" => {"id" => String, "external_id" => String, "business_information" => {"name" => String, "type" => String, "website" => String, "identification_number" => String, "year_established" => Number, "annual_revenue" => {"value" => Number, "amount" => Number, "currency" => String}, "fulltime_employees" => Integer, "parttime_employees" => Integer}, "industry" => {"type" => String, "class_code" => String, "subclass_code" => String}, "addresses" => Array[{"type" => String, "address_line" => String, "city" => String, "state" => String, "country_code" => String, "postal_code" => String}], "email" => String, "phone_number" => String}}, "404" => {"errors" => Array[{"source" => String, "type" => String, "message" => String}]} }') }
       end
     end
 
     describe "#parameters_for_method" do
       describe 'path /oauth/token' do
-        it { expect(subject.parameters_for_method).to eq("body, options = {}") }
+        it { expect(subject.parameters_for_method).to eq('body, options = {}') }
       end
 
       describe 'path /accounts/{id}' do
         let(:path_method) { ["/accounts/{id}", "get"] }
-        it { expect(subject.parameters_for_method).to eq("id, options = {}") }
+        it { expect(subject.parameters_for_method).to eq('id, options = {}') }
       end
 
       describe 'path /pet/{petId}' do
         let(:path_method) { ["/pet/{petId}", "delete"] }
-        it { expect(subject.parameters_for_method).to eq("petId, options = {}") }
+        it { expect(subject.parameters_for_method).to eq('petId, options = {}') }
       end
     end
 
     describe "#typed_parameters_for_method" do
       describe 'path /oauth/token' do
-        it { expect(subject.typed_parameters_for_method).to eq("({ grant_type: String, client_id: String, client_secret: String, scope: String } body, ?Hash[untyped, untyped] options)") }
+        it { expect(subject.typed_parameters_for_method).to eq('({ "grant_type" => String, "client_id" => String, "client_secret" => String, "scope" => String } body, ?Hash[untyped, untyped] options)') }
       end
 
       describe 'path /accounts/{id}' do
         let(:path_method) { ["/accounts/{id}", "get"] }
-        it { expect(subject.typed_parameters_for_method).to eq("(String id, ?Hash[untyped, untyped] options)") }
+        it { expect(subject.typed_parameters_for_method).to eq('(String id, ?Hash[untyped, untyped] options)') }
       end
 
       describe 'path /pet/{petId}' do
         let(:path_method) { ["/pet/{petId}", "delete"] }
-        it { expect(subject.typed_parameters_for_method).to eq("(String petId, ?Hash[untyped, untyped] options)") }
+        it { expect(subject.typed_parameters_for_method).to eq('(String petId, ?Hash[untyped, untyped] options)') }
       end
 
       describe 'path /user/{username}' do
         let(:path_method) { ["/user/{username}", "put"] }
-        it { expect(subject.typed_parameters_for_method).to eq("(String username, { id: Integer, username: String, firstName: String, lastName: String, email: String, password: String, phone: String, userStatus: Integer } body, ?Hash[untyped, untyped] options)") }
+        it { expect(subject.typed_parameters_for_method).to eq('(String username, { "id" => Integer, "username" => String, "firstName" => String, "lastName" => String, "email" => String, "password" => String, "phone" => String, "userStatus" => Integer } body, ?Hash[untyped, untyped] options)') }
       end
     end
 
@@ -110,7 +110,7 @@ describe 'Swagger2Rbs::RestEndpoint' do
         let(:path_method) { ["/pet/{petId}", "delete"] }
         it "" do
           result = subject.to_yaml
-          expect(result[:method_name]).to eq("deletePet")
+          expect(result[:method_name]).to eq('deletePet')
           expect(result[:path_parameters]).to eq(["petId"])
           expect(result[:body]).to eq({})
         end
@@ -120,7 +120,7 @@ describe 'Swagger2Rbs::RestEndpoint' do
         let(:path_method) { ["/pet", "put"] }
         it "to_yaml" do
           result = subject.to_yaml
-          expect(result[:method_name]).to eq("updatePet")
+          expect(result[:method_name]).to eq('updatePet')
           expect(result[:path_parameters]).to eq([])
           expect(result[:body]).to eq({"id"=>"integer", "name"=>"string", "category"=>{"id"=>"integer", "name"=>"string"}, "photoUrls"=>["string"], "tags"=>[{"id"=>"integer", "name"=>"string"}], "status"=>"string"})
         end
@@ -142,7 +142,7 @@ describe 'Swagger2Rbs::RestEndpoint' do
     describe "#body_typed" do
       describe 'path /oauth/token' do
         let(:path_method) { ["/oauth/token", "post"] }
-        it { expect(subject.body_typed).to eq("{ grant_type: String, client_id: String, client_secret: String, scope: String }") }
+        it { expect(subject.body_typed).to eq('{ "grant_type" => String, "client_id" => String, "client_secret" => String, "scope" => String }') }
       end
 
       describe 'path /accounts/{id}' do
@@ -154,7 +154,7 @@ describe 'Swagger2Rbs::RestEndpoint' do
         let(:path_method) { ["/accounts/{id}/contacts", "post"] }
         it do
           expect(subject.body_typed)
-            .to eq("{ account_id: String, relationship: String, first_name: String, last_name: String, email: String, communications_opt_out: String, contact_numbers: Array[{type: String, number: String}] }")
+            .to eq('{ "account_id" => String, "relationship" => String, "first_name" => String, "last_name" => String, "email" => String, "communications_opt_out" => String, "contact_numbers" => Array[{"type" => String, "number" => String}] }')
         end
       end
 
@@ -162,7 +162,7 @@ describe 'Swagger2Rbs::RestEndpoint' do
         let(:path_method) { ["/data/v1/policy", "post"] }
         it do
           expect(subject.body_typed)
-          .to eq("{ payloads: Array[{identifier: {externalIdField: String, value: String}, data: {Account: {UUID: String}, InsuranceType: String}}] }")
+          .to eq('{ "payloads" => Array[{"identifier" => {"externalIdField" => String, "value" => String}, "data" => {"Account" => {"UUID" => String}, "InsuranceType" => String}}] }')
         end
       end
 
@@ -170,7 +170,7 @@ describe 'Swagger2Rbs::RestEndpoint' do
         let(:path_method) { ["/certificates", "post"] }
         it do
           expect(subject.body_typed)
-            .to eq("{ type: String, policy_ids: Array[String], fields: {holder_name: String} }")
+            .to eq('{ "type" => String, "policy_ids" => Array[String], "fields" => {"holder_name" => String} }')
         end
       end
     end

--- a/spec/rest_endpoint_spec.rb
+++ b/spec/rest_endpoint_spec.rb
@@ -18,7 +18,7 @@ describe 'Swagger2Rbs::RestEndpoint' do
       it 'nil values' do
         data = { "400" => nil, "200" => { success: "string" } }
         result = subject.write_types(data)
-        expect(result).to eq("{ 400: untyped, 200: {success: String} }")
+        expect(result).to eq('{ "400" => untyped, "200" => {"success" => String} }')
       end
 
       it 'array' do

--- a/spec/rest_endpoint_spec.rb
+++ b/spec/rest_endpoint_spec.rb
@@ -47,6 +47,13 @@ describe 'Swagger2Rbs::RestEndpoint' do
       end
     end
 
+    describe "#all_responses_typed" do
+      describe 'path /accounts/{id} 200' do
+        let(:path_method) { ["/accounts/{id}", "get"] }
+        it { expect(subject.all_responses_typed).to eq("{ 200: {data: {id: String, external_id: String, business_information: {name: String, type: String, website: String, identification_number: String, year_established: Number, annual_revenue: {value: Number, amount: Number, currency: String}, fulltime_employees: Integer, parttime_employees: Integer}, industry: {type: String, class_code: String, subclass_code: String}, addresses: Array[{type: String, address_line: String, city: String, state: String, country_code: String, postal_code: String}], email: String, phone_number: String}}, 404: {errors: Array[{source: String, type: String, message: String}]} }") }
+      end
+    end
+
     describe "#parameters_for_method" do
       describe 'path /oauth/token' do
         it { expect(subject.parameters_for_method).to eq("body, options = {}") }

--- a/spec/rest_endpoint_spec.rb
+++ b/spec/rest_endpoint_spec.rb
@@ -15,18 +15,18 @@ describe 'Swagger2Rbs::RestEndpoint' do
     }
 
     it '#method_name' do
-      expect(subject.method_name).to eq('get_access_token')
+      expect(subject.method_name).to eq("get_access_token")
     end
 
     describe "#path_with_parameters" do
       describe 'path /oauth/token' do
         let(:path_method) { ["/oauth/token", "post"] }
-        it { expect(subject.path_with_parameters).to eq('/oauth/token') }
+        it { expect(subject.path_with_parameters).to eq("/oauth/token") }
       end
 
       describe 'path /accounts/{id}' do
         let(:path_method) { ["/accounts/{id}", "get"] }
-        it { expect(subject.path_with_parameters).to eq('/accounts/#{id}') }
+        it { expect(subject.path_with_parameters).to eq("/accounts/\#{id}") }
       end
     end
 
@@ -34,11 +34,6 @@ describe 'Swagger2Rbs::RestEndpoint' do
       describe 'path /oauth/token 200' do
         let(:path_method) { ["/oauth/token", "post"] }
         it { expect(subject.response_typed("200")).to eq('{ "access_token" => String, "token_type" => String, "expires_in" => Integer, "scope" => String, "created_at" => Integer }') }
-      end
-
-      describe 'path /accounts/{id} 200' do
-        let(:path_method) { ["/accounts/{id}", "get"] }
-        it { expect(subject.response_typed("200")).to eq('{ "data" => {"id" => String, "external_id" => String, "business_information" => {"name" => String, "type" => String, "website" => String, "identification_number" => String, "year_established" => Number, "annual_revenue" => {"value" => Number, "amount" => Number, "currency" => String}, "fulltime_employees" => Integer, "parttime_employees" => Integer}, "industry" => {"type" => String, "class_code" => String, "subclass_code" => String}, "addresses" => Array[{"type" => String, "address_line" => String, "city" => String, "state" => String, "country_code" => String, "postal_code" => String}], "email" => String, "phone_number" => String} }') }
       end
 
       describe 'path /accounts/{id} 404' do
@@ -50,44 +45,44 @@ describe 'Swagger2Rbs::RestEndpoint' do
     describe "#all_responses_typed" do
       describe 'path /accounts/{id} 200' do
         let(:path_method) { ["/accounts/{id}", "get"] }
-        it { expect(subject.all_responses_typed).to eq('{ "200" => {"data" => {"id" => String, "external_id" => String, "business_information" => {"name" => String, "type" => String, "website" => String, "identification_number" => String, "year_established" => Number, "annual_revenue" => {"value" => Number, "amount" => Number, "currency" => String}, "fulltime_employees" => Integer, "parttime_employees" => Integer}, "industry" => {"type" => String, "class_code" => String, "subclass_code" => String}, "addresses" => Array[{"type" => String, "address_line" => String, "city" => String, "state" => String, "country_code" => String, "postal_code" => String}], "email" => String, "phone_number" => String}}, "404" => {"errors" => Array[{"source" => String, "type" => String, "message" => String}]} }') }
+        it { expect(subject.all_responses_typed).to eq("{ \"200\" => {\"data\" => {\"id\" => String, \"external_id\" => String, \"business_information\" => {\"name\" => String, \"type\" => String, \"website\" => String, \"identification_number\" => String, \"year_established\" => Number, \"annual_revenue\" => {\"value\" => Number, \"amount\" => Number, \"currency\" => String}, \"fulltime_employees\" => Integer, \"parttime_employees\" => Integer}, \"industry\" => {\"type\" => String, \"class_code\" => String, \"subclass_code\" => String}, \"addresses\" => Array[{\"type\" => String, \"address_line\" => String, \"city\" => String, \"state\" => String, \"country_code\" => String, \"postal_code\" => String}], \"email\" => String, \"phone_number\" => String}}, \"404\" => {\"errors\" => Array[{\"source\" => String, \"type\" => String, \"message\" => String}]} }") }
       end
     end
 
     describe "#parameters_for_method" do
       describe 'path /oauth/token' do
-        it { expect(subject.parameters_for_method).to eq('body, options = {}') }
+        it { expect(subject.parameters_for_method).to eq("body, options = {}") }
       end
 
       describe 'path /accounts/{id}' do
         let(:path_method) { ["/accounts/{id}", "get"] }
-        it { expect(subject.parameters_for_method).to eq('id, options = {}') }
+        it { expect(subject.parameters_for_method).to eq("id, options = {}") }
       end
 
       describe 'path /pet/{petId}' do
         let(:path_method) { ["/pet/{petId}", "delete"] }
-        it { expect(subject.parameters_for_method).to eq('petId, options = {}') }
+        it { expect(subject.parameters_for_method).to eq("petId, options = {}") }
       end
     end
 
     describe "#typed_parameters_for_method" do
       describe 'path /oauth/token' do
-        it { expect(subject.typed_parameters_for_method).to eq('({ "grant_type" => String, "client_id" => String, "client_secret" => String, "scope" => String } body, ?Hash[untyped, untyped] options)') }
+        it { expect(subject.typed_parameters_for_method).to eq("({ grant_type: String, client_id: String, client_secret: String, scope: String } body, ?Hash[untyped, untyped] options)") }
       end
 
       describe 'path /accounts/{id}' do
         let(:path_method) { ["/accounts/{id}", "get"] }
-        it { expect(subject.typed_parameters_for_method).to eq('(String id, ?Hash[untyped, untyped] options)') }
+        it { expect(subject.typed_parameters_for_method).to eq("(String id, ?Hash[untyped, untyped] options)") }
       end
 
       describe 'path /pet/{petId}' do
         let(:path_method) { ["/pet/{petId}", "delete"] }
-        it { expect(subject.typed_parameters_for_method).to eq('(String petId, ?Hash[untyped, untyped] options)') }
+        it { expect(subject.typed_parameters_for_method).to eq("(String petId, ?Hash[untyped, untyped] options)") }
       end
 
       describe 'path /user/{username}' do
         let(:path_method) { ["/user/{username}", "put"] }
-        it { expect(subject.typed_parameters_for_method).to eq('(String username, { "id" => Integer, "username" => String, "firstName" => String, "lastName" => String, "email" => String, "password" => String, "phone" => String, "userStatus" => Integer } body, ?Hash[untyped, untyped] options)') }
+        it { expect(subject.typed_parameters_for_method).to eq("(String username, { id: Integer, username: String, firstName: String, lastName: String, email: String, password: String, phone: String, userStatus: Integer } body, ?Hash[untyped, untyped] options)") }
       end
     end
 
@@ -96,7 +91,7 @@ describe 'Swagger2Rbs::RestEndpoint' do
         let(:path_method) { ["/pet/{petId}", "delete"] }
         it "" do
           result = subject.to_yaml
-          expect(result[:method_name]).to eq('deletePet')
+          expect(result[:method_name]).to eq("deletePet")
           expect(result[:path_parameters]).to eq(["petId"])
           expect(result[:body]).to eq({})
         end
@@ -106,7 +101,7 @@ describe 'Swagger2Rbs::RestEndpoint' do
         let(:path_method) { ["/pet", "put"] }
         it "to_yaml" do
           result = subject.to_yaml
-          expect(result[:method_name]).to eq('updatePet')
+          expect(result[:method_name]).to eq("updatePet")
           expect(result[:path_parameters]).to eq([])
           expect(result[:body]).to eq({"id"=>"integer", "name"=>"string", "category"=>{"id"=>"integer", "name"=>"string"}, "photoUrls"=>["string"], "tags"=>[{"id"=>"integer", "name"=>"string"}], "status"=>"string"})
         end
@@ -128,7 +123,7 @@ describe 'Swagger2Rbs::RestEndpoint' do
     describe "#body_typed" do
       describe 'path /oauth/token' do
         let(:path_method) { ["/oauth/token", "post"] }
-        it { expect(subject.body_typed).to eq('{ "grant_type" => String, "client_id" => String, "client_secret" => String, "scope" => String }') }
+        it { expect(subject.body_typed).to eq("{ grant_type: String, client_id: String, client_secret: String, scope: String }") }
       end
 
       describe 'path /accounts/{id}' do
@@ -140,7 +135,7 @@ describe 'Swagger2Rbs::RestEndpoint' do
         let(:path_method) { ["/accounts/{id}/contacts", "post"] }
         it do
           expect(subject.body_typed)
-            .to eq('{ "account_id" => String, "relationship" => String, "first_name" => String, "last_name" => String, "email" => String, "communications_opt_out" => String, "contact_numbers" => Array[{"type" => String, "number" => String}] }')
+            .to eq("{ account_id: String, relationship: String, first_name: String, last_name: String, email: String, communications_opt_out: String, contact_numbers: Array[{type: String, number: String}] }")
         end
       end
 
@@ -148,7 +143,7 @@ describe 'Swagger2Rbs::RestEndpoint' do
         let(:path_method) { ["/data/v1/policy", "post"] }
         it do
           expect(subject.body_typed)
-          .to eq('{ "payloads" => Array[{"identifier" => {"externalIdField" => String, "value" => String}, "data" => {"Account" => {"UUID" => String}, "InsuranceType" => String}}] }')
+          .to eq("{ payloads: Array[{identifier: {externalIdField: String, value: String}, data: {Account: {UUID: String}, InsuranceType: String}}] }")
         end
       end
 
@@ -156,7 +151,7 @@ describe 'Swagger2Rbs::RestEndpoint' do
         let(:path_method) { ["/certificates", "post"] }
         it do
           expect(subject.body_typed)
-            .to eq('{ "type" => String, "policy_ids" => Array[String], "fields" => {"holder_name" => String} }')
+            .to eq("{ type: String, policy_ids: Array[String], fields: {holder_name: String} }")
         end
       end
     end

--- a/spec/rest_endpoint_spec.rb
+++ b/spec/rest_endpoint_spec.rb
@@ -31,14 +31,19 @@ describe 'Swagger2Rbs::RestEndpoint' do
     end
 
     describe "#response_typed" do
-      describe 'path /oauth/token' do
+      describe 'path /oauth/token 200' do
         let(:path_method) { ["/oauth/token", "post"] }
-        it { expect(subject.response_typed).to eq("{ access_token: String, token_type: String, expires_in: Integer, scope: String, created_at: Integer }") }
+        it { expect(subject.response_typed("200")).to eq("{ access_token: String, token_type: String, expires_in: Integer, scope: String, created_at: Integer }") }
       end
 
-      describe 'path /accounts/{id}' do
+      describe 'path /accounts/{id} 200' do
         let(:path_method) { ["/accounts/{id}", "get"] }
-        it { expect(subject.response_typed).to eq("{ data: {id: String, external_id: String, business_information: {name: String, type: String, website: String, identification_number: String, year_established: Number, annual_revenue: {value: Number, amount: Number, currency: String}, fulltime_employees: Integer, parttime_employees: Integer}, industry: {type: String, class_code: String, subclass_code: String}, addresses: Array[{type: String, address_line: String, city: String, state: String, country_code: String, postal_code: String}], email: String, phone_number: String} }") }
+        it { expect(subject.response_typed("200")).to eq("{ data: {id: String, external_id: String, business_information: {name: String, type: String, website: String, identification_number: String, year_established: Number, annual_revenue: {value: Number, amount: Number, currency: String}, fulltime_employees: Integer, parttime_employees: Integer}, industry: {type: String, class_code: String, subclass_code: String}, addresses: Array[{type: String, address_line: String, city: String, state: String, country_code: String, postal_code: String}], email: String, phone_number: String} }") }
+      end
+
+      describe 'path /accounts/{id} 404' do
+        let(:path_method) { ["/accounts/{id}", "get"] }
+        it { expect(subject.response_typed("404")).to eq("{ errors: Array[{source: String, type: String, message: String}] }") }
       end
     end
 

--- a/spec/rest_endpoint_spec.rb
+++ b/spec/rest_endpoint_spec.rb
@@ -14,20 +14,6 @@ describe 'Swagger2Rbs::RestEndpoint' do
       Swagger2Rbs::RestEndpoint.new(path_method[0], path_method[1], path_props)
     }
 
-    describe "#write_types" do
-      it 'nil values' do
-        data = { "400" => nil, "200" => { "success" => "string" } }
-        result = subject.write_types(data)
-        expect(result).to eq('{ "400" => untyped, "200" => {"success" => String} }')
-      end
-
-      it 'array' do
-        data = { "errors" => [{ "success" => "string" }] }
-        result = subject.write_types(data)
-        expect(result).to eq('{ "errors" => Array[{"success" => String}] }')
-      end
-    end
-
     it '#method_name' do
       expect(subject.method_name).to eq('get_access_token')
     end

--- a/spec/rest_endpoint_spec.rb
+++ b/spec/rest_endpoint_spec.rb
@@ -14,6 +14,20 @@ describe 'Swagger2Rbs::RestEndpoint' do
       Swagger2Rbs::RestEndpoint.new(path_method[0], path_method[1], path_props)
     }
 
+    describe "#write_types" do
+      it 'nil values' do
+        data = { "400" => nil, "200" => { success: "string" } }
+        result = subject.write_types(data)
+        expect(result).to eq("{ 400: untyped, 200: {success: String} }")
+      end
+
+      it 'array' do
+        data = { "errors" => [{ success: "string" }] }
+        result = subject.write_types(data)
+        expect(result).to eq("{ errors: Array[{success: String}] }")
+      end
+    end
+
     it '#method_name' do
       expect(subject.method_name).to eq("get_access_token")
     end


### PR DESCRIPTION
Response with types


```ruby
def getPetById: (String petId, ?Hash[untyped, untyped] options) -> [HTTParty::Response, { "200" => {"id" => Integer, "name" => String, "category" => {"id" => Integer, "name" => String}, "photoUrls" => Array[String], "tags" => Array[{"id" => Integer, "name" => String}], "status" => String}, "400" => untyped, "404" => untyped }]
```

```ruby
api = MyApi.new
response, data = api.getPetById("1)
data["200"]["id"]
```

All methods return a tuple, the second element contains all responses in a hash with the correct rbs types.